### PR TITLE
Fix typo in cython.yml

### DIFF
--- a/.github/workflows/cython.yml
+++ b/.github/workflows/cython.yml
@@ -82,4 +82,4 @@ jobs:
           cd cython
           python -m pip install -U pip setuptools wheel
           python setup.py build_ext -i
-          python runtests.py -vv --no-code-style -x Debugger --backends=${{ matrix.bbackend }} -j7
+          python runtests.py -vv --no-code-style -x Debugger --backends=${{ matrix.backend }} -j7


### PR DESCRIPTION
I think this is stopping the majority of the tests from running.

See https://github.com/cython/cython/pull/4471#issuecomment-980230790