### PR TITLE
Skip compiling Cython

### DIFF
--- a/.github/workflows/cython.yml
+++ b/.github/workflows/cython.yml
@@ -81,5 +81,4 @@ jobs:
         run: |
           cd cython
           python -m pip install -U pip setuptools wheel
-          python setup.py build_ext -i
           python runtests.py -vv --no-code-style -x Debugger --backends=${{ matrix.bbackend }} -j7


### PR DESCRIPTION
Cython doesn't really need to be compiled to work, and it's the kind of code that I'd expect PyPy's own JIT to do pretty well on.

I'd therefore suggest removing the "build Cython" step - if there are any bugs in PyPy+Cython that do affect the compiled version of Cython then they'll probably be quite hard to debug too.

https://github.com/cython/cython/pull/4471#issuecomment-980230790