### PR TITLE
add pybind11 CI run

### DIFF
--- a/.github/workflows/pybind11.yml
+++ b/.github/workflows/pybind11.yml
@@ -1,0 +1,167 @@
+name: CI
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  schedule:
+  #        ┌───────────── minute (0 - 59)
+  #        │ ┌───────────── hour (0 - 23)
+  #        │ │ ┌───────────── day of the month (1 - 31)
+  #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │ │ │ │ │
+  - cron: "0 2 * * 0"
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_ONLY_BINARY: numpy
+  FORCE_COLOR: 3
+  PYTEST_TIMEOUT: 300
+
+jobs:
+  # This is the "main" test suite, which tests a large number of different
+  # versions of default compilers and Python versions in GitHub Actions.
+  standard:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, windows-2022, macos-latest]
+        python:
+        - 'pypy-3.8-nightly'
+        - 'pypy-3.9-nightly'
+
+        # Items in here will either be added to the build matrix (if not
+        # present), or add new keys to an existing matrix element if all the
+        # existing keys match.
+        #
+        # We support an optional key: args, for cmake args
+        include:
+          - runs-on: ubuntu-latest
+            python: 'pypy-3.8-nightly'
+            args: >
+              -DPYBIND11_FINDPYTHON=ON
+
+    name: "pybind11 ${{ matrix.python }} • ${{ matrix.runs-on }} x64 ${{ matrix.args }}"
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: pytest-dev/pytest-html
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Setup Boost (Linux)
+      # Can't use boost + define _
+      if: runner.os == 'Linux'
+      run: sudo apt-get install libboost-dev
+
+    - name: Setup Boost (macOS)
+      if: runner.os == 'macOS'
+      run: brew install boost
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.12
+
+    - name: Cache wheels
+      if: runner.os == 'macOS'
+      uses: actions/cache@v3
+      with:
+        # This path is specific to macOS - we really only need it for PyPy NumPy wheels
+        # See https://github.com/actions/cache/blob/master/examples.md#python---pip
+        # for ways to do this more generally
+        path: ~/Library/Caches/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
+        key: ${{ runner.os }}-pip-${{ matrix.python }}-x64-${{ hashFiles('tests/requirements.txt') }}
+
+    - name: Prepare env
+      run: |
+        python -m pip install -r tests/requirements.txt
+
+    - name: Setup annotations on Linux
+      if: runner.os == 'Linux'
+      run: python -m pip install pytest-github-actions-annotate-failures
+
+    # First build - C++11 mode and inplace
+    - name: Configure C++11 ${{ matrix.args }}
+      run: >
+        cmake -S . -B .
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=11
+        ${{ matrix.args }}
+
+    - name: Build C++11
+      run: cmake --build . -j 2
+
+    - name: Python tests C++11
+      run: cmake --build . --target pytest -j 2
+
+    - name: C++11 tests
+      # TODO: Figure out how to load the DLL on Python 3.8+
+      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10' || matrix.python == '3.11-dev' || matrix.python == 'pypy-3.8'))"
+      run: cmake --build .  --target cpptest -j 2
+
+    - name: Interface test C++11
+      run: cmake --build . --target test_cmake_build
+
+    - name: Clean directory
+      run: git clean -fdx
+
+    # Second build - C++17 mode and in a build directory
+    - name: Configure C++17
+      run: >
+        cmake -S . -B build2
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=17
+        ${{ matrix.args }}
+
+    - name: Build
+      run: cmake --build build2 -j 2
+
+    - name: Python tests
+      run: cmake --build build2 --target pytest
+
+    - name: C++ tests
+      # TODO: Figure out how to load the DLL on Python 3.8+
+      if: "!(runner.os == 'Windows' && (matrix.python == 3.8 || matrix.python == 3.9 || matrix.python == '3.10' || matrix.python == '3.11-dev' || matrix.python == 'pypy-3.8'))"
+      run: cmake --build build2 --target cpptest
+
+    # Third build - C++17 mode with unstable ABI
+    - name: Configure (unstable ABI)
+      run: >
+        cmake -S . -B build3
+        -DPYBIND11_WERROR=ON
+        -DDOWNLOAD_CATCH=ON
+        -DDOWNLOAD_EIGEN=ON
+        -DCMAKE_CXX_STANDARD=17
+        -DPYBIND11_INTERNALS_VERSION=10000000
+        "-DPYBIND11_TEST_OVERRIDE=test_call_policies.cpp;test_gil_scoped.cpp;test_thread.cpp"
+        ${{ matrix.args }}
+
+    - name: Build (unstable ABI)
+      run: cmake --build build3 -j 2
+
+    - name: Python tests (unstable ABI)
+      run: cmake --build build3 --target pytest
+
+    - name: Interface test
+      run: cmake --build build2 --target test_cmake_build
+
+

--- a/.github/workflows/pybind11.yml
+++ b/.github/workflows/pybind11.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        repository: pytest-dev/pytest-html
+        repository: pybind/pybind11
 
     - name: Setup Python ${{ matrix.python }}
       uses: actions/setup-python@v4

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python_version: [pypy-3.7-nightly, pypy-3.8-nightly, pypy-3.9-nightly]
+        python_version: [pypy-3.8-nightly, pypy-3.9-nightly]
 
     timeout-minutes: 20
 

--- a/.github/workflows/pytest-html.yml
+++ b/.github/workflows/pytest-html.yml
@@ -24,16 +24,9 @@ jobs:
     name: pytest-html ${{ matrix.name }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            name: pypy3-ubuntu
-            python-version: pypy-3.8
-
-          - os: windows-latest
-            name: pypy3-windows
-            python-version: pypy-3.8
-
           - os: ubuntu-latest
             name: pypy3-nightly-ubuntu
             python-version: pypy-3.8-nightly

--- a/.github/workflows/pythran.yml
+++ b/.github/workflows/pythran.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         cpp-version: [g++-5, clang-5.0]
-        python_version: ["3.8", pypy-3.8-nightly, pypy-3.9-nightly]
+        python_version: [pypy-3.8-nightly, pypy-3.9-nightly]
 
     timeout-minutes: 160
 


### PR DESCRIPTION
also clean up other runs a bit
- remove pypy3.7
- add `fail-fast: False`
- remove release CI runs, no need to retest and retest