### PR TITLE
add windows numpy CI run with PYPY_ENABLE_WINCONSOLEIO=1

### DIFF
--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -29,11 +29,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python_version: [pypy-3.11-nightly]
+        include:
+          - os: windows-latest
+            PYPY_ENABLE_WINCONSOLEIO: 1 
 
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.2.2
       with:
         repository: numpy/numpy
         path: repo

--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -23,20 +23,18 @@ jobs:
     env:
       BITS: 64
       NPY_USE_BLAS_ILP64: '1'
+      PYPY_ENABLE_WINCONSOLEIO: '1'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python_version: [pypy-3.11-nightly]
-        include:
-          - os: windows-latest
-            PYPY_ENABLE_WINCONSOLEIO: 1 
 
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v4.1.1
       with:
         repository: numpy/numpy
         path: repo


### PR DESCRIPTION
after pypy/pypy#5139, maybe now win32consoleio does not crash?